### PR TITLE
Provide assets to Sprockets if Rails not available

### DIFF
--- a/font-awesome-sass.gemspec
+++ b/font-awesome-sass.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_runtime_dependency 'sass-rails', '>= 3.1.1'
+  spec.add_runtime_dependency 'sass', '>= 3.1.1'
+  spec.add_runtime_dependency 'sprockets'
 end

--- a/lib/font/awesome/sass.rb
+++ b/lib/font/awesome/sass.rb
@@ -1,10 +1,7 @@
 require "font/awesome/sass/version"
 
-module Font
-  module Awesome
-    module Sass
-      require 'font/awesome/sass/engine'
-      require 'font/awesome/sass/version'
-    end
-  end
+if defined?(Rails::Engine)
+  require 'font/awesome/sass/engine'
+else
+  require 'font/awesome/sass/sprockets'
 end

--- a/lib/font/awesome/sass/sprockets.rb
+++ b/lib/font/awesome/sass/sprockets.rb
@@ -1,0 +1,4 @@
+require 'sprockets'
+
+Sprockets.append_path File.expand_path('../../../../../vendor/assets/fonts', __FILE__)
+Sprockets.append_path File.expand_path('../../../../../vendor/assets/stylesheets', __FILE__)


### PR DESCRIPTION
So glad you guys are putting together an official gem for font-awesome!  No need to tie it directly to Rails, though.  Made a few changes to open it up for any app with a Sprockets-based asset pipeline.  I've got a Sinatra app with Sprockets, and with these changes it works perfectly.   Should still work for Rails, too, just fine.