### PR TITLE
no need depend sass-rails, remove it

### DIFF
--- a/font-awesome-sass.gemspec
+++ b/font-awesome-sass.gemspec
@@ -20,6 +20,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-
-  spec.add_runtime_dependency 'sass-rails', '>= 3.1.1'
 end

--- a/lib/font/awesome/sass.rb
+++ b/lib/font/awesome/sass.rb
@@ -1,8 +1,7 @@
 module Font
   module Awesome
     module Sass
-      require 'font/awesome/sass/engine'
-      require 'font/awesome/sass/version'
+      require 'font/awesome/sass/engine' if defined?(::Rails)
     end
   end
 end


### PR DESCRIPTION
Fixed #6

There is no need to depend `sass-rails`, and we can use `defined?(::Rails)` to test whether the app is a rails application

now, many non-rails app could enjoy font-awesome :)
