### PR TITLE
Helpers for non-Rails usage.

### DIFF
--- a/lib/font/awesome/sass.rb
+++ b/lib/font/awesome/sass.rb
@@ -1,8 +1,24 @@
 module Font
   module Awesome
     module Sass
-      require 'font/awesome/sass/engine'
+      require 'font/awesome/sass/engine' if defined?(Rails)
       require 'font/awesome/sass/version'
+
+      def self.gem_path
+        File.expand_path('../../../..', __FILE__)
+      end
+
+      def self.assets_path
+        File.join(gem_path, 'vendor', 'assets')
+      end
+
+      def self.fonts_path
+        File.join(assets_path, 'fonts')
+      end
+
+      def self.stylesheets_path
+        File.join(assets_path, 'stylesheets')
+      end
     end
   end
 end


### PR DESCRIPTION
Makes this gem usable for non-Rails environments, as well as some helpers to get at the underlying paths. I'm using this in Nanoc w/ Compass and would happy to write up a little guide for the readme if that would help.
