### PR TITLE
Add depend_on_asset for all fonts to make rails asset pipeline happy.

### DIFF
--- a/vendor/assets/stylesheets/font-awesome.scss
+++ b/vendor/assets/stylesheets/font-awesome.scss
@@ -24,6 +24,11 @@
  *  Work: Lead Product Designer @ Kyruus - http://kyruus.com
  */
 
+//= depend_on_asset "fontawesome-webfont.eot"
+//= depend_on_asset "fontawesome-webfont.svg"
+//= depend_on_asset "fontawesome-webfont.ttf"
+//= depend_on_asset "fontawesome-webfont.woff"
+
 @import "font-awesome/variables";
 @import "font-awesome/mixins";
 @import "font-awesome/path";


### PR DESCRIPTION
It is now mandatory to add `depend_on_asset` on assets that reference other assets to make rails asset pipeline happy, as described in [here](https://github.com/rails/sprockets-rails/pull/96). 

I thought that it was only mandatory for `erb` assets, but my sprockets complained that `depend_on_asset "fontawesome-webfont.eot` should be added to `font-awesome.scss`, and when I did, it stopped complaining. I think that this is because `scss` files must be precompiled anyway, so `sprockets` picks this up.

This gem is not usable in rails if these lines aren't added. When I updated `sprockets` I detected these problems in your gem and another, so please see [this discussion](https://github.com/joliss/jquery-ui-rails/pull/59) for further reference.

I tested this with the following gem versions:

``` ruby
gem 'rails', '3.2.16'
ruby '2.0.0'
gem 'sprockets', '2.2.2.backport2'
gem 'sprockets-rails', '2.0.0.backport1'
```

Should work for `rails 4` as well, although I didn't test it.

Cheers and Merry Xmas :)
