### PR TITLE
Use font-url path for proper asset compiling

### DIFF
--- a/vendor/assets/stylesheets/font-awesome/_path.scss
+++ b/vendor/assets/stylesheets/font-awesome/_path.scss
@@ -3,11 +3,11 @@
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url('./fontawesome-webfont.eot?v=#{$fa-version}');
-  src: url('./fontawesome-webfont.eot?#iefix&v=#{$fa-version}') format('embedded-opentype'),
-    url('./fontawesome-webfont.woff?v=#{$fa-version}') format('woff'),
-    url('./fontawesome-webfont.ttf?v=#{$fa-version}') format('truetype'),
-    url('./fontawesome-webfont.svg?v=#{$fa-version}#fontawesomeregular') format('svg');
+  src: font-url('fontawesome-webfont.eot?v=#{$fa-version}');
+  src: font-url('fontawesome-webfont.eot?#iefix&v=#{$fa-version}') format('embedded-opentype'),
+       font-url('fontawesome-webfont.woff?v=#{$fa-version}') format('woff'),
+       font-url('fontawesome-webfont.ttf?v=#{$fa-version}') format('truetype'),
+       font-url('fontawesome-webfont.svg?v=#{$fa-version}#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
`font-url` should be used so that the Asset Pipeline can point to the compiled version of the font.
