### PR TITLE
Fix gem_path, now the compass extension actually works.

### DIFF
--- a/lib/font_awesome/sass.rb
+++ b/lib/font_awesome/sass.rb
@@ -12,7 +12,7 @@ module FontAwesome
       end
 
       def gem_path
-        @gem_path ||= File.expand_path('..', File.dirname(__FILE__))
+        @gem_path ||= File.expand_path('../..', File.dirname(__FILE__))
       end
 
       def stylesheets_path


### PR DESCRIPTION
Since sass.rb was in a folder deeper the gem_path included lib. This was not correct.
