### PR TITLE
support sprockets only

### DIFF
--- a/font-awesome-sass.gemspec
+++ b/font-awesome-sass.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'sass-rails'
   spec.add_development_dependency 'compass'
 
+  spec.add_runtime_dependency 'sprockets'
   spec.add_runtime_dependency 'sass', '~> 3.2'
 end

--- a/lib/font_awesome/sass.rb
+++ b/lib/font_awesome/sass.rb
@@ -4,11 +4,14 @@ module FontAwesome
       def load!
         if rails?
           register_rails_engine
+        else
+          register_sprocket_path
         end
 
         if compass?
           register_compass_extension
         end
+
       end
 
       def gem_path
@@ -50,6 +53,12 @@ module FontAwesome
         require 'sass-rails'
         require 'font_awesome/sass/rails/engine'
         require 'font_awesome/sass/rails/railtie'
+      end
+
+      def register_sprocket_path
+        require 'sprockets'
+        Sprockets.append_path File.expand_path('../../../vendor/assets/fonts',__FILE__)
+        Sprockets.append_path File.expand_path('../../../vendor/assets/stylesheets',__FILE__)
       end
     end
   end


### PR DESCRIPTION
this enables the gem to be used in sinatra apps aswell instead of
forcing the user to use rails

I updated the original pull request (#1) from @flintinatux to
work with the current codebase