### PR TITLE
The 'text' argument for 'icon' helper method made optional

### DIFF
--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -2,7 +2,8 @@ module FontAwesome
   module Sass
     module Rails
       module ViewHelpers
-        def icon(icon, text="", html_options={})
+        def icon(icon, text=nil, html_options={})
+          text, html_options = nil, text if text.is_a?(Hash)
           content_class = "fa fa-#{icon}"
           content_class << " #{html_options[:class]}" if html_options.key?(:class)
           html_options[:class] = content_class


### PR DESCRIPTION
HTML options can now be specified without passing an empty argument.

Documentation may also need updating (https://github.com/FortAwesome/font-awesome-sass#rails-helper-usage).