### PR TITLE
Change icon helper input params

### DIFF
--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -2,7 +2,10 @@ module FontAwesome
   module Sass
     module Rails
       module ViewHelpers
-        def icon(icon, text="", html_options={})
+        def icon(icon, *args)
+          text, html_options = args
+          html_options = text if text.is_a?(Hash)
+          
           content_class = "fa fa-#{icon}"
           content_class << " #{html_options[:class]}" if html_options.key?(:class)
           html_options[:class] = content_class


### PR DESCRIPTION
I often want to add html options like a class to my icons, but it's not very often i want to have text. That means that i end up writing `nil` all the time (fx. `<%= icon :user, nil, class: "color-blue" %>`). 

This pull request should fix that problem, and still be backwards compatible :) 

Before:
```erb
<%= icon :spinner, nil, class: "fa-spin" %>
#=> <i class="fa fa-spinner fa-spin"></i>

<%= icon :spinner, class: "fa-spin" %>
#=> <i class="fa fa-spinner">{ class: "fa-spin"}</i>

<%= icon :spinner, "Loading", class: "fa-spin" %>
#=> <i class="fa fa-spinner fa-spin">Loading</i>
```
After
```erb
<%= icon :spinner, nil, class: "fa-spin" %>
#=> <i class="fa fa-spinner fa-spin"></i>

<%= icon :spinner, class: "fa-spin" %>
#=> <i class="fa fa-spinner fa-spin"></i>

<%= icon :spinner, "Loading", class: "fa-spin" %>
#=> <i class="fa fa-spinner fa-spin">Loading</i>
```