### PR TITLE
support text inside the icon and changed the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # FontAwesome::Sass
 
-'font-awesome-sass' is a Sass-powered version of FontAwesome for your Ruby projects and plays nicely with 
+'font-awesome-sass' is a Sass-powered version of FontAwesome for your Ruby projects and plays nicely with
  Ruby on Rails, Compass, Sprockets, etc.
- 
+
  Refactored to support more Ruby environments with code and documentation humbly used from the excellent
- [bootstrap-sass](https://github.com/twbs/bootstrap-sass) project by the Bootstrap team 
+ [bootstrap-sass](https://github.com/twbs/bootstrap-sass) project by the Bootstrap team
 
 ## Installation
 
@@ -45,16 +45,24 @@ icon('flag')
 ```
 
 ```ruby
-icon('flag', '', class: 'strong')
+icon('flag', {}, class: 'strong')
 # => <i class="fa fa-flag strong"></i>
 ```
 
 ```ruby
-icon('flag', 'Font Awesome', id: 'my-icon', class: 'strong')
+icon('flag', text: 'Font Awesome', id: 'my-icon', class: 'strong')
 # => <i id="my-icon" class="fa fa-flag strong"></i> Font Awesome
 ```
 
-Note: the icon helper can take a hash of options that will be passed to the content_tag helper
+```ruby
+icon('flag', text: 'Font Awesome', icon_text: content_tag(:em, "4", class: 'badge'), id: 'my-icon', class: 'strong')
+# => <i id="my-icon" class="fa fa-flag strong"><em class="badge">4</em></i> Font Awesome
+```
+
+Note: the icon helper can take a hash of options among them:
+- text: The text to be appended **after** the icon node.
+- icon_text: The text to be inserter **inside** the icon node.
+- any other HTML option that will be passed down to the icon like class, id, etc.
 
 ### b. Compass without Rails
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ icon('flag')
 ```
 
 ```ruby
-icon('flag', {}, class: 'strong')
+icon('flag', class: 'strong')
 # => <i class="fa fa-flag strong"></i>
 ```
 

--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -10,7 +10,7 @@ module FontAwesome
           text = options.delete(:text)
           icon_text = options.delete(:icon_text)
 
-          html = content_tag(:i, icon_text, html_options)
+          html = content_tag(:i, icon_text, options)
           html << " #{text}" unless text.blank?
           html.html_safe
         end

--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -10,7 +10,7 @@ module FontAwesome
           text = options.delete(:text)
           icon_text = options.delete(:icon_text)
 
-          html = content_tag(:i, icon_text.html_safe, html_options)
+          html = content_tag(:i, icon_text, html_options)
           html << " #{text}" unless text.blank?
           html.html_safe
         end

--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -10,7 +10,7 @@ module FontAwesome
           text = options.delete(:text)
           icon_text = options.delete(:icon_text)
 
-          html = content_tag(:i, icon_text, html_options)
+          html = content_tag(:i, icon_text.html_safe, html_options)
           html << " #{text}" unless text.blank?
           html.html_safe
         end

--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -2,12 +2,15 @@ module FontAwesome
   module Sass
     module Rails
       module ViewHelpers
-        def icon(icon, text="", html_options={})
+        def icon(icon, options={})
           content_class = "fa fa-#{icon}"
-          content_class << " #{html_options[:class]}" if html_options.key?(:class)
-          html_options[:class] = content_class
+          content_class << " #{options[:class]}" if options.key?(:class)
+          options[:class] = content_class
 
-          html = content_tag(:i, nil, html_options)
+          text = options.delete(:text)
+          icon_text = options.delete(:icon_text)
+
+          html = content_tag(:i, icon_text, html_options)
           html << " #{text}" unless text.blank?
           html.html_safe
         end


### PR DESCRIPTION
Updated icon helper and documentation

```ruby
icon('flag', text: 'Font Awesome', id: 'my-icon', class: 'strong')
 # => <i id="my-icon" class="fa fa-flag strong"></i> Font Awesome
 ```
 
-Note: the icon helper can take a hash of options that will be passed to the content_tag helper
```ruby
icon('flag', text: 'Font Awesome', icon_text: content_tag(:em, "4", class: 'badge'), id: 'my-icon', class: 'strong')
# => <i id="my-icon" class="fa fa-flag strong"><em class="badge">4</em></i> Font Awesome
```

Note: the icon helper can take a hash of options among them:
- text: The text to be appended **after** the icon node.
- icon_text: The text to be inserter **inside** the icon node.
- any other HTML option that will be passed down to the icon like class, id, etc.