### PR TITLE
Added stacked_icon helper

### DIFF
--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -11,6 +11,13 @@ module FontAwesome
           html << " #{text}" unless text.blank?
           html.html_safe
         end
+
+        def stacked_icon(icon1, icon2, html_options={})
+          content_class = "fa-stack"
+          content_class << " #{html_options[:class]}" if html_options.key?(:class)
+          html_options[:class] = content_class
+          content_tag(:span, icon1+icon2, html_options).html_safe
+        end
       end
     end
   end


### PR DESCRIPTION
This feature is from issue https://github.com/FortAwesome/font-awesome-sass/issues/59

**Usage**

``` erb
<%= stacked_icon(
  icon("camera", "", class: "fa-stack-1x"), # The first icon to stack
  icon("ban", "", class: "fa-stack-2x text-danger"), # The second icon to stack
  class: "fa-lg" # Additional classes for fa-stack
) %>
```

**Output**

``` html
<span class="fa-stack fa-lg"><i class="fa fa-camera fa-stack-1x"></i><i class="fa fa-ban fa-stack-2x text-danger"></i></span>
```
