### PR TITLE
Add missing require for FontAwesome::Sass::VERSION

### DIFF
--- a/lib/font-awesome-sass.rb
+++ b/lib/font-awesome-sass.rb
@@ -52,6 +52,8 @@ module FontAwesome
       end
 
       def register_compass_extension
+        require 'font_awesome/sass/version'
+
         ::Compass::Frameworks.register(
             'font-awesome',
             :version               => FontAwesome::Sass::VERSION,


### PR DESCRIPTION
The latest version of font-awesome-sass could't be loaded properly in Rails apps, which is caused by Compass registration changes in 77946cba28609cbec2c54e15cdcf9f0828cc78b8

This pull request should fix the issue.