### PR TITLE
Fix for:  NameError: uninitialized constant FontAwesome::Sass::VERSION

### DIFF
--- a/lib/font-awesome-sass.rb
+++ b/lib/font-awesome-sass.rb
@@ -1,3 +1,5 @@
+require 'font_awesome/sass/version'
+
 module FontAwesome
   module Sass
     class << self


### PR DESCRIPTION
Getting this error (in a Rails 4.1 project, when I bundle update to latest gem versions):

    NameError: uninitialized constant FontAwesome::Sass::VERSION
    /Users/jash/.rvm/gems/ruby-2.2.0@global_youth_day/gems/font-awesome-sass-4.3.0/lib/font-awesome-sass.rb:57:in `register_compass_extension'
    /Users/jash/.rvm/gems/ruby-2.2.0@global_youth_day/gems/font-awesome-sass-4.3.0/lib/font-awesome-sass.rb:5:in `load!'
    /Users/jash/.rvm/gems/ruby-2.2.0@global_youth_day/gems/font-awesome-sass-4.3.0/lib/font-awesome-sass.rb:79:in `<top (required)>'
    /Users/jash/.rvm/gems/ruby-2.2.0@global_youth_day/gems/bundler-1.7.12/lib/bundler/runtime.rb:76:in `require'

Solution is simply to require the version file first.