### PR TITLE
Converted comments to Sass style

### DIFF
--- a/assets/stylesheets/font-awesome.scss
+++ b/assets/stylesheets/font-awesome.scss
@@ -1,7 +1,5 @@
-/*!
- *  Font Awesome 4.3.0 by @davegandy - http://fontawesome.io - @fontawesome
- *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
- */
+// Font Awesome 4.3.0 by @davegandy - http://fontawesome.io - @fontawesome
+// License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
 
 @import "font-awesome/variables";
 @import "font-awesome/mixins";


### PR DESCRIPTION
Comments should use the Sass style, so as not to cause surprising behavior with e.g. `output-style= :compressed`.