### PR TITLE
Remove excrescent path to javasctipts

### DIFF
--- a/lib/font-awesome-sass.rb
+++ b/lib/font-awesome-sass.rb
@@ -72,7 +72,6 @@ module FontAwesome
       def register_sprockets
         Sprockets.append_path(stylesheets_path)
         Sprockets.append_path(fonts_path)
-        Sprockets.append_path(javascripts_path)
       end
     end
   end


### PR DESCRIPTION
Adding of this path was a cause of a fail:

```
13:03:02 web.1  | started with pid 65000
13:03:16 web.1  | ~/.rvm/gems/ruby-2.1.2/gems/font-awesome-sass-4.3.1/lib/font-awesome-sass.rb:75:in `register_sprockets': undefined local variable or method `javascripts_path' for FontAwesome::Sass:Module (NameError)
13:03:16 web.1  | 	from ~/.rvm/gems/ruby-2.1.2/gems/font-awesome-sass-4.3.1/lib/font-awesome-sass.rb:10:in `load!'
13:03:16 web.1  | 	from ~/.rvm/gems/ruby-2.1.2/gems/font-awesome-sass-4.3.1/lib/font-awesome-sass.rb:81:in `<top (required)>'
...
```
