### PR TITLE
Bug Fix - undefined method 'key?' for Nil Class

### DIFF
--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -4,7 +4,7 @@ module FontAwesome
       module ViewHelpers
         def icon(icon, *args)
           text, html_options = args
-          html_options = text if text.is_a?(Hash)
+          text.is_a?(Hash) ? html_options = text : html_options = {}
           
           content_class = "fa fa-#{icon}"
           content_class << " #{html_options[:class]}" if html_options.key?(:class)


### PR DESCRIPTION
When no options passed, html_options was not defined and L10 caused undefined method 'key?' for Nil Class.

Fixes undefined method `key?' for nil:NilClass error for simple icon usage

i.e. <%= icon('home') %>