### PR TITLE
Fix appending non-strings to icon

### DIFF
--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -11,7 +11,7 @@ module FontAwesome
           html_options[:class] = content_class
 
           html = content_tag(:i, nil, html_options)
-          html << ' ' << text unless text.blank?
+          html << ' ' << text.to_s unless text.blank?
           html
         end
       end


### PR DESCRIPTION
Example: `icon(:copyright, Time.now.year)`

Before: © ߟ
After: © 2015