### PR TITLE
adds fix for icon helper when no optional arguments are present

### DIFF
--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -5,7 +5,8 @@ module FontAwesome
         def icon(icon, *args)
           text, html_options = args
           html_options = text if text.is_a?(Hash)
-          
+          html_options = {} if html_options.blank?
+
           content_class = "fa fa-#{icon}"
           content_class << " #{html_options[:class]}" if html_options.key?(:class)
           html_options[:class] = content_class


### PR DESCRIPTION
Currently, a call to the icon helper with no optional arguments like  

`icon('flag')`  

will raise the error `undefined method keys? for nil:NilClass`

I wrote a one-line fix that sets `html_options` to an empty hash in this case. 