### PR TITLE
Fix Rails asset pre-compilation

### DIFF
--- a/lib/font_awesome/sass/rails/engine.rb
+++ b/lib/font_awesome/sass/rails/engine.rb
@@ -2,7 +2,7 @@ module FontAwesome
   module Sass
     module Rails
       class Engine < ::Rails::Engine
-        initializer 'font-awesome-sass.assets.precompile' do |app|
+        initializer 'font-awesome-sass.assets.precompile', group: :all do |app|
           %w(stylesheets fonts).each do |sub|
             app.config.assets.paths << root.join('assets', sub).to_s
           end


### PR DESCRIPTION
We were seeing boxes instead of font-awesome icons in our Rails staging environment.

Debugging rake assets:precompile showed that the FontAwesome::Sass::RailsEngine initializer was not getting run.

Adding it to the group 'all' fixed this.

This may be a fix for issues https://github.com/FortAwesome/font-awesome-sass/issues/62 and https://github.com/FortAwesome/font-awesome-sass/issues/90