### PR TITLE
Helper#icon prepends fa- to given fa class string

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ icon('flag')
 ```
 
 ```ruby
+icon('flag 2x')
+# => <i class="fa fa-flag fa-2x"></i>
+```
+
+```ruby
 icon('flag', class: 'strong')
 # => <i class="fa fa-flag strong"></i>
 ```

--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -5,8 +5,8 @@ module FontAwesome
         def icon(icon, text = nil, html_options = {})
           text, html_options = nil, text if text.is_a?(Hash)
 
-          icons = icon.split(" ").map { |icon| "fa-#{icon}" }.join(" ")
-          content_class = "fa #{icons}"
+          icons = icon.is_a?(Array) ? icon : icon.to_s.split(" ")
+          content_class = "fa #{icons.map { |i| "fa-#{i}" }.join(' ')}"
           content_class << " #{html_options[:class]}" if html_options.key?(:class)
           html_options[:class] = content_class
 

--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -5,7 +5,8 @@ module FontAwesome
         def icon(icon, text = nil, html_options = {})
           text, html_options = nil, text if text.is_a?(Hash)
 
-          content_class = "fa fa-#{icon}"
+          icons = icon.split(" ").map { |icon| "fa-#{icon}" }.join(" ")
+          content_class = "fa #{icons}"
           content_class << " #{html_options[:class]}" if html_options.key?(:class)
           html_options[:class] = content_class
 


### PR DESCRIPTION
I made the improvement on the helper method. Now it can handle multiple `fa-` classes. 

For example, to add `fa-2x` class we need to use `icon('flag', class='fa-2x')` which make more sense to use it as the following.

``` ruby
icon('flag 2x')
# => <i class="fa fa-flag fa-2x"></i>
```
