### PR TITLE
Add compatibility with sprockets v4

### DIFF
--- a/lib/font_awesome/sass/rails/engine.rb
+++ b/lib/font_awesome/sass/rails/engine.rb
@@ -7,7 +7,9 @@ module FontAwesome
             app.config.assets.paths << root.join('assets', sub).to_s
           end
 
-          app.config.assets.precompile << %r(font-awesome/fontawesome-webfont\.(?:eot|svg|ttf|woff|woff2?)$)
+          %w(eot svg ttf woff woff2).each do |ext|
+            app.config.assets.precompile << "font-awesome/fontawesome-webfont.#{ext}"
+          end
         end
       end
     end


### PR DESCRIPTION
Fix issue #114 caused by rails/sprockets-rails#269 which raise an error when compiling assets in rails

```
ActionView::Template::Error (undefined method `start_with?' for /font-awesome\/fontawesome-webfont\.(?:eot|svg|ttf|woff|woff2?)$/:Regexp):
```

Remove regex in assets precompile in `Rails::Engine` in favour of adding simple strings to array.