### PR TITLE
Require sassc-rails if available, fallback to sass-rails otherwise

### DIFF
--- a/lib/font-awesome-sass.rb
+++ b/lib/font-awesome-sass.rb
@@ -63,7 +63,11 @@ module FontAwesome
       end
 
       def register_rails_engine
-        require 'sass-rails'
+        begin
+          require 'sassc-rails'
+        rescue LoadError => e
+          require 'sass-rails'
+        end
         require 'font_awesome/sass/rails/engine'
         require 'font_awesome/sass/rails/railtie'
       end


### PR DESCRIPTION
Attempt to solve issue #112 
