### PR TITLE
Define templates as Compass extension

### DIFF
--- a/templates/project/manifest.rb
+++ b/templates/project/manifest.rb
@@ -3,15 +3,12 @@ description 'FontAwesome for Sass'
 # Stylesheet importing font-awesome
 stylesheet 'styles.sass'
 
-# Copy JS and fonts
+# Copy fonts
 manifest = Pathname.new(File.dirname(__FILE__))
 assets   = File.expand_path('../../assets', manifest)
-{:javascript => 'javascripts',
- :font       => 'fonts'
-}.each do |method, dir|
-  root = Pathname.new(assets).join(dir)
-  Dir.glob root.join('**', '*.*') do |path|
-    path = Pathname.new(path)
-    send method, path.relative_path_from(manifest).to_s, :to => path.relative_path_from(root).to_s
-  end
+
+fonts = Pathname.new(assets).join('fonts')
+Dir.glob fonts.join('**', '*.*') do |path|
+  path = Pathname.new(path)
+  font path.relative_path_from(manifest).to_s, :to => path.relative_path_from(fonts).to_s
 end

--- a/templates/project/manifest.rb
+++ b/templates/project/manifest.rb
@@ -1,0 +1,17 @@
+description 'FontAwesome for Sass'
+
+# Stylesheet importing font-awesome
+stylesheet 'styles.sass'
+
+# Copy JS and fonts
+manifest = Pathname.new(File.dirname(__FILE__))
+assets   = File.expand_path('../../assets', manifest)
+{:javascript => 'javascripts',
+ :font       => 'fonts'
+}.each do |method, dir|
+  root = Pathname.new(assets).join(dir)
+  Dir.glob root.join('**', '*.*') do |path|
+    path = Pathname.new(path)
+    send method, path.relative_path_from(manifest).to_s, :to => path.relative_path_from(root).to_s
+  end
+end

--- a/templates/project/styles.sass
+++ b/templates/project/styles.sass
@@ -1,0 +1,4 @@
+// Import FontAwesome Compass integration
+@import "font-awesome-compass"
+// Import FontAwesome for Sass
+@import "font-awesome"


### PR DESCRIPTION
I tried to install font-awesome's fonts and styles to my site whose assets are managed with `compass`.  but nothing happen when `compass install font-awesome ./ -r font-awesome-sass` as the gem doesn't have any template for Compass. 

This pull-request provides templates so that it works as compass extension. After Merging this PR,  the fonts can be installed to projects managed with compass. 
