### PR TITLE
Make compass version find fonts

### DIFF
--- a/assets/stylesheets/_font-awesome-compass.scss
+++ b/assets/stylesheets/_font-awesome-compass.scss
@@ -1,5 +1,5 @@
 @function fa-font-path($path) {
-  @return font-url($path, true);
+  @return font-path($path);
 }
 
 $fa-sass-asset-helper: true;


### PR DESCRIPTION
Currently when using font-awesome with compass but not ruby it issues the following error messages:

`WARNING: 'fontawesome-webfont.eot?v=4.7.0' was not found (or cannot be read) in ... (directory containing config.rb)`

This issue is documented [here](https://github.com/FortAwesome/font-awesome-sass/issues/45) and results from failing to look in the assets directory for the fonts.  It was previously fixed for sprockets but it appears this change did not propagate to _font-awesome-compass.scss.

I only use Sass occasionally and I'm just making an educated guess that this won't break something important (doesn't seem to for me) but it eliminates the errors.  Hopefully I'm correct and this is all fine.