### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ includes the sprockets assets helper Sass functions used for finding the proper 
 @import "font-awesome";
 ```
 
+If `app/assets/stylesheets/application.css.scss` does not exist then rename `app/assets/stylesheets/application.css` and add the `@import` statements below the `*= require` statements but outside of the comment block.
+
 #### Rails Helper usage
 
 In your view:


### PR DESCRIPTION
Extra info for Rails 5 which has `app/assets/stylesheets/application.css` and not `app/assets/stylesheets/application.css.scss`.