### PR TITLE
Skip loading sass-rails, loading sass is enough

### DIFF
--- a/lib/font-awesome-sass.rb
+++ b/lib/font-awesome-sass.rb
@@ -63,7 +63,6 @@ module FontAwesome
       end
 
       def register_rails_engine
-        require 'sass-rails'
         require 'font_awesome/sass/rails/engine'
         require 'font_awesome/sass/rails/railtie'
       end


### PR DESCRIPTION
This should make the gem compatible with sassc-rails as well as sass-rails (from issue #112). There is no reason this gem should need to call require `sass-rails`, as the parent Rails app should decide what railties it needs and either:

1. Have `sass-rails` already included
2. Be using an alternative like `sassc-rails`