### PR TITLE
Add Size Control Option to Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ icon('fab', 'font-awesome', 'Font Awesome', id: 'my-icon', class: 'strong')
 # => <i id="my-icon" class="fab fa-font-awesome strong"></i> Font Awesome
 ```
 
+Size control:
+
+```ruby
+icon('fas', 'flag', size: 'lg')
+# => <i class="fas fa-flag fa-lg"></i>
+```
+
+Available size options: `xs`, `sm`, `lg` and `2x` through `10x`.
+
 Note: the icon helper can take a hash of options that will be passed to the content_tag helper
 
 ### b. Compass without Rails

--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -7,6 +7,7 @@ module FontAwesome
 
           content_class = "#{style} fa-#{name}"
           content_class << " #{html_options[:class]}" if html_options.key?(:class)
+          content_class << " fa-#{html_options[:size]}"; html_options.delete(:size) if html_options.key?(:size)
           html_options[:class] = content_class
 
           html = content_tag(:i, nil, html_options)


### PR DESCRIPTION
Added an ability to accept `size` option argument to `icon` helper.

The README file is also updated accordingly.