### PR TITLE
Request `sassc` gem instead of `sass` during configuration

### DIFF
--- a/lib/font-awesome-sass.rb
+++ b/lib/font-awesome-sass.rb
@@ -45,7 +45,7 @@ module FontAwesome
       private
 
       def configure_sass
-        require 'sass'
+        require 'sassc'
 
         ::Sass.load_paths << stylesheets_path
       end


### PR DESCRIPTION
The gem spec defines that the `sassc` gem is a dependency, but the code used to require `sass` gem.

Closes #168 