### PR TITLE
fix: actually use $fa-font-display

### DIFF
--- a/assets/stylesheets/font-awesome/_path.scss
+++ b/assets/stylesheets/font-awesome/_path.scss
@@ -2,6 +2,7 @@
  * -------------------------- */
 
  @font-face {
+   font-display: $fa-font-display;
    font-family: 'Font Awesome 5 Free';
    font-style: normal;
    font-weight: 900;
@@ -14,6 +15,7 @@
  }
 
  @font-face {
+  font-display: $fa-font-display;
   font-family: 'Font Awesome 5 Free';
   font-style: normal;
   font-weight: 400;
@@ -26,6 +28,7 @@
 }
 
 @font-face {
+  font-display: $fa-font-display;
   font-family: 'Font Awesome 5 Brands';
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
I am not sure why, but the `$fa-font-display` variable was not actually used, so I added it to the font faces.

This might be a breaking change, refer to [this issue](https://github.com/FortAwesome/Font-Awesome/issues/14387) as well.