### PR TITLE
Add symbol snake to kebab case conversion on #icon helper

### DIFF
--- a/lib/font_awesome/sass/rails/helpers.rb
+++ b/lib/font_awesome/sass/rails/helpers.rb
@@ -5,6 +5,9 @@ module FontAwesome
         def icon(style, name, text = nil, html_options = {})
           text, html_options = nil, text if text.is_a?(Hash)
 
+          style = style.to_s.gsub(/_/, "-") if style.is_a?(Symbol)
+          name = name.to_s.gsub(/_/, "-") if name.is_a?(Symbol)
+
           content_class = "#{style} fa-#{name}"
           content_class << " #{html_options[:class]}" if html_options.key?(:class)
           html_options[:class] = content_class


### PR DESCRIPTION
I generally find it a lot more pleasing to be able to do something like this:
```ruby
icon :fa_brands, :behance_square
```

And have it behave the same as:
```ruby
icon "fa-brands", "behance-square"
```
