### PR TITLE
Support other Sass processors

### DIFF
--- a/font-awesome-sass.gemspec
+++ b/font-awesome-sass.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'sassc', '~> 2.0'
-
   spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'rake'
 end

--- a/lib/font-awesome-sass.rb
+++ b/lib/font-awesome-sass.rb
@@ -1,3 +1,17 @@
+begin
+  require 'sassc'
+rescue LoadError
+  begin
+    require 'sassc-embedded'
+  rescue LoadError
+    begin
+      require 'sass-embedded'
+    rescue LoadError
+      raise LoadError.new('font-awesome-sass-rubygem requires a Sass engine. Please add dartsass-sprockets, sassc-rails, dartsass-rails or cssbundling-rails to your dependencies.')
+    end
+  end
+end
+
 module FontAwesome
   module Sass
     class << self


### PR DESCRIPTION
This is a proposal for supporting Dart Sass in addition to Sassc. It emulates how Dart Sass support was added for the Bootstrap gem via https://github.com/twbs/bootstrap-rubygem/pull/271. It addresses #221 and #222.

Let me know if you have any suggestions or feedback on the approach.