### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/font-awesome-sass.gemspec
+++ b/font-awesome-sass.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   s.metadata = {
-    'changelog_uri' => "#{spec.homepage}/releases/tag/#{spec.version}"
+    'changelog_uri' => 'https://fontawesome.com/changelog'
   }
 
   spec.add_runtime_dependency 'sassc', '~> 2.0'

--- a/font-awesome-sass.gemspec
+++ b/font-awesome-sass.gemspec
@@ -18,6 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  s.metadata = {
+    'changelog_uri' => "#{spec.homepage}/releases/tag/#{spec.version}"
+  }
+
   spec.add_runtime_dependency 'sassc', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '>= 1.3'


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata Useful for running https://github.com/MaximeD/gem_updater