### PR TITLE
fix: undefined local variable or method `s'

### DIFF
--- a/font-awesome-sass.gemspec
+++ b/font-awesome-sass.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  s.metadata = {
+  spec.metadata = {
     'changelog_uri' => 'https://fontawesome.com/changelog'
   }
 


### PR DESCRIPTION
I'm not sure how nobody else has complained about this...

The repo gemspec is invalid, referencing an `s` variable that doesn't exist